### PR TITLE
Migrate ci to git hub actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+---
+name: tests
+on: [push]
+jobs:
+  plugin-tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    container:
+      image: buildkite/plugin-tester:latest
+      volumes:
+        - "${{github.workspace}}:/plugin"
+    steps:
+      - uses: actions/checkout@v2
+      - name: tests
+        run: bats tests/
+  plugin-lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    container:
+      image: buildkite/plugin-linter:latest
+      volumes:
+        - "${{github.workspace}}:/plugin"
+    steps:
+      - uses: actions/checkout@v2
+      - name: lint
+        run: lint --id envato/stop-the-line
+  plugin-shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@1.1.0
+        with:
+          check_together: 'yes'
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: lint
-        run: lint --id envato/stop-the-line
+        run: lint --id envato/ejson2env
   plugin-shellcheck:
     name: Shellcheck
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ejson2env Buildkite Plugin
 
-A Buildkite plugin for exporting environment variables stored inside [ejson](https://github.com/Shopify/ejson) files using [ejson2env](https://github.com/Shopify/ejson2env).
+[![tests](https://github.com/envato/ejson2env-buildkite-plugin/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/envato/ejson2env-buildkite-plugin/actions/workflows/tests.yml)
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ejson2env Buildkite Plugin
 
+A Buildkite plugin for exporting environment variables stored inside [ejson](https://github.com/Shopify/ejson) files using [ejson2env](https://github.com/Shopify/ejson2env).
+
 [![tests](https://github.com/envato/ejson2env-buildkite-plugin/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/envato/ejson2env-buildkite-plugin/actions/workflows/tests.yml)
 
 ## Example


### PR DESCRIPTION
### Context

We have [a sensible default](https://docs.envato.net/architecture-guild/sensible-defaults/expected/open-source-ci.html) to **not** use our internal Buildkite agents to run CI for open-source projects.

However, we're doing that for a number of open-source Buildkite plugins. (Probably historical, before the default was in-place.) Let's update these projects to use GitHub Actions.


### Considerations

An [example GitHub Actions configuration](https://github.com/envato/heroku-container-deploy-buildkite-plugin/blob/16f73f647bbb6e5cca4217ec5413e6e3d3bb2f41/.github/workflows/test.yml) we can use for inspiration (or copy).

- Adding a YAML file to the `.github/workflows/` directory should be enough to enable GitHub actions
- Delete Buildkite pipelines by navigating to their settings page in a browser and click the `Delete Pipeline` in the pipeline management section